### PR TITLE
Print the SAVer version on top of the help message.

### DIFF
--- a/src/saver.c
+++ b/src/saver.c
@@ -21,6 +21,7 @@
 #include "abstract_classifiers/abstract_classifier.h"
 #include "counterexamples/counterexample_seeker.h"
 
+#define SAVER_VERSION "v1.0"
 
 /**
  * Prints detailed debug information about analysis of a single sample.
@@ -67,6 +68,7 @@ void check_soundness(
 static void display_help(const int argc, const char *argv[]) {
     (void) argc;
 
+    fprintf(stderr, "SAVer %s\n", SAVER_VERSION);
     fprintf(stderr, "Usage: %s <path to classifier> <path to dataset> [abstraction] [perturbation] [perturbation parameters] [--counterexamples_file <path>]\n", argv[0]);
     fprintf(stderr, "Detailed parameter description:\n");
     fprintf(stderr, "\t- <path to classifier>: Relative or absolute path to classifier file\n");


### PR DESCRIPTION
Hi,

From the repository on GitHub, one can infer that SAVer is at version `v1.0`, but there is no such information in the displayed help message.

This little PR adds a simple preamble to the current help message of the form: `SAVer v1.0`. In the code, the version is actually defined in a macro.

Let me know what you think. 